### PR TITLE
Add a minimum time criterion

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Read the [Introduction Article](https://www.fline.dev/introducing-reviewkit/?ref
    ```Swift
    import ReviewKit
    // ...
-   ReviewKit.criteria = ReviewCriteria(minPositiveEventsWeight: 5, eventsExpireAfterDays: 30)
+   ReviewKit.criteria = ReviewCriteria(minPositiveEventsWeight: 5, eventsExpireAfterDays: 30, minimumTimeBeforeRequest: DateComponents(day: 1))
    ```
 
 3. Determine common workflows in your app and when a user completes one of them, call this:

--- a/Sources/ReviewKit/ReviewCriteria.swift
+++ b/Sources/ReviewKit/ReviewCriteria.swift
@@ -4,12 +4,15 @@ import Foundation
 public struct ReviewCriteria {
    let minPositiveEventsWeight: Int
    let eventsExpireAfterDays: Int
+   let minimumTimeBeforeRequest: DateComponents
 
    /// - Parameters:
    ///   - minPositiveEventsWeight: The minimum positive events weight that needs to be surpassed to request a review. With the default event weight, this equals the number of events.
    ///   - eventsExpireAfterDays: The relevant time interval to consider events within when looking into the past. Events outside this time period expire and get deleted from persistent storage.
-   public init(minPositiveEventsWeight: Int, eventsExpireAfterDays: Int) {
+    ///  - minimumTimeBeforeRequest: The minimum time period between the first active (un-expired) positive event and the current time to request the review. For example, setting this to 1 day will require that the first un-expired positive event be at least 1 day in the past before requesting the review. This can prevent a user who's trying out the app for the first time from receiving the review request. This is disabled by default. To manually disable it, set some component to 0, e.g. `DateComponents(day: 0)`.
+   public init(minPositiveEventsWeight: Int, eventsExpireAfterDays: Int, minimumTimeBeforeRequest: DateComponents = DateComponents(day: 0)) {
       self.minPositiveEventsWeight = minPositiveEventsWeight
       self.eventsExpireAfterDays = eventsExpireAfterDays
+      self.minimumTimeBeforeRequest = minimumTimeBeforeRequest
    }
 }

--- a/Sources/ReviewKit/ReviewKit.swift
+++ b/Sources/ReviewKit/ReviewKit.swift
@@ -33,7 +33,10 @@ public enum ReviewKit {
       #endif
 
       let totalPositiveEventsWeight = self.positiveEvents.reduce(into: 0, { $0 += $1.weight })
-      if totalPositiveEventsWeight >= self.criteria.minPositiveEventsWeight {
+      let firstPositiveEventDate = self.positiveEvents.first?.date ?? .distantFuture
+      let requiredDateToRequestReview = Calendar.current.date(byAdding: criteria.minimumTimeBeforeRequest, to: firstPositiveEventDate)
+
+      if totalPositiveEventsWeight >= self.criteria.minPositiveEventsWeight, let requiredDateToRequestReview, requiredDateToRequestReview < Date() {
          #if os(iOS)
          if
             #available(iOS 14.0, *),


### PR DESCRIPTION
Fixes #2 

## Proposed Changes
  - Add an optional minimum time criterion between the first active positive event and the current time
